### PR TITLE
Add resource use when building tiles

### DIFF
--- a/assets/definitions/resources.yml
+++ b/assets/definitions/resources.yml
@@ -1,0 +1,5 @@
+resources:
+  - id: METAL
+    price: 10.0
+  - id: ELECTRONICS
+    price: 20.0

--- a/assets/definitions/tiles.yml
+++ b/assets/definitions/tiles.yml
@@ -2,6 +2,9 @@ tiles:
   - id: BLUE_FLOOR
     height: FLOOR
     category: STRUCTURE
+    buildResources:
+      - id: METAL
+        amount: 5
     components:
       - type: STRUCTURE
       - type: WALKABLE
@@ -87,6 +90,9 @@ tiles:
   - id: WALL
     height: FLOOR | KNEE | WAIST | CHEST | HEAD
     category: STRUCTURE
+    buildResources:
+      - id: METAL
+        amount: 15
     components:
       - type: STRUCTURE
       - type: SOLID
@@ -175,6 +181,11 @@ tiles:
   - id: OXYGEN_PRODUCER
     height: KNEE | WAIST | CHEST
     category: OXYGEN
+    buildResources:
+      - id: METAL
+        amount: 5
+      - id: ELECTRONICS
+        amount: 10
     components:
       - type: POWER_CONNECTOR
       - type: POWER_CONSUMER
@@ -190,6 +201,11 @@ tiles:
   - id: BATTERY
     height: KNEE | WAIST
     category: POWER
+    buildResources:
+      - id: METAL
+        amount: 10
+      - id: ELECTRONICS
+        amount: 10
     components:
       - type: POWER_CONNECTOR
       - type: BATTERY
@@ -202,6 +218,11 @@ tiles:
   - id: SOLAR_PANEL
     height: KNEE
     category: POWER
+    buildResources:
+      - id: METAL
+        amount: 8
+      - id: ELECTRONICS
+        amount: 12
     components:
       - type: POWER_CONNECTOR
       - type: POWER_PRODUCER
@@ -215,6 +236,9 @@ tiles:
   - id: FRAME
     height: FLOOR
     category: STRUCTURE
+    buildResources:
+      - id: METAL
+        amount: 3
     components:
       - type: STRUCTURE
       - type: WALKABLE
@@ -223,6 +247,11 @@ tiles:
   - id: DOOR
     height: KNEE | WAIST | CHEST | HEAD
     category: STRUCTURE
+    buildResources:
+      - id: METAL
+        amount: 15
+      - id: ELECTRONICS
+        amount: 5
     components:
       - type: POWER_CONNECTOR
       - type: POWER_CONSUMER
@@ -237,6 +266,9 @@ tiles:
   - id: WIRE
     height: POWER
     category: POWER
+    buildResources:
+      - id: METAL
+        amount: 1
     components:
       - type: POWER_CONNECTOR
       - type: DURABILITY

--- a/src/def_manager.hpp
+++ b/src/def_manager.hpp
@@ -27,11 +27,23 @@ namespace c4
     }
 }
 
+struct ResourceDef
+{
+    const std::string id;
+    const float price;
+
+    ResourceDef(const std::string &id, float price) : id(id), price(price) {}
+
+    constexpr const std::string &GetId() const { return id; }
+    constexpr float GetPrice() const { return price; }
+};
+
 struct DefinitionManager
 {
 protected:
     std::unordered_map<std::string, std::shared_ptr<TileDef>> tileDefinitions;
     std::unordered_map<std::string, std::shared_ptr<EffectDef>> effectDefinitions;
+    std::unordered_map<std::string, std::shared_ptr<ResourceDef>> resourceDefinitions;
 
     DefinitionManager() = default;
     ~DefinitionManager() = default;
@@ -58,6 +70,16 @@ public:
     static std::shared_ptr<EffectDef> GetEffectDefinition(const std::string &effectId)
     {
         return DefinitionManager::GetInstance().effectDefinitions.at(effectId);
+    }
+
+    static const std::unordered_map<std::string, std::shared_ptr<ResourceDef>> &GetResourceDefinitions()
+    {
+        return DefinitionManager::GetInstance().resourceDefinitions;
+    }
+
+    static std::shared_ptr<ResourceDef> GetResourceDefinition(const std::string &resourceId)
+    {
+        return DefinitionManager::GetInstance().resourceDefinitions.at(resourceId);
     }
 
     // Resolve a slash-separated path (e.g. "ui/textColor") against a node and return
@@ -104,5 +126,6 @@ public:
 
     static void ParseTilesFromFile(const std::string &filename);
     static void ParseEffectsFromFile(const std::string &filename);
+    static void ParseResourcesFromFile(const std::string &filename);
     static void ParseConstantsFromFile(const std::string &filename);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ int main()
                 DrawDragSelectBox();
                 DrawMainTooltip();
                 DrawFpsCounter();
+                DrawResourceUI();
             }
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ int main()
     AssetManager::Initialize();
     GameManager::GetLua().open_libraries(sol::lib::base, sol::lib::math, sol::lib::table, sol::lib::string);
     RegisterAllLuaBindings(GameManager::GetLua());
+    DefinitionManager::ParseResourcesFromFile("../assets/definitions/resources.yml");
     DefinitionManager::ParseTilesFromFile("../assets/definitions/tiles.yml");
     DefinitionManager::ParseEffectsFromFile("../assets/definitions/env_effects.yml");
 

--- a/src/station.hpp
+++ b/src/station.hpp
@@ -15,6 +15,7 @@ struct Station : public std::enable_shared_from_this<Station>
     std::vector<std::shared_ptr<Effect>> effects;
     std::vector<std::shared_ptr<PowerGrid>> powerGrids;
     std::vector<std::shared_ptr<PlannedTask>> plannedTasks;
+    std::unordered_map<std::string, int> resources;
 
 public:
     std::shared_ptr<Tile> GetTileAtPosition(const Vector2Int &pos, TileDef::Height height = TileDef::Height::NONE) const;
@@ -49,6 +50,11 @@ public:
     void AddPlannedTask(const Vector2Int &pos, const std::string &tileId, bool isBuild);
     void CompletePlannedTask(const Vector2Int &pos);
     bool HasPlannedTaskAt(const Vector2Int &pos) const;
+
+    int GetResourceCount(const std::string &resourceId) const;
+    void AddResource(const std::string &resourceId, int amount);
+    bool HasResources(const std::unordered_map<std::string, int> &requiredResources) const;
+    void ConsumeResources(const std::unordered_map<std::string, int> &resourcesToConsume);
 };
 
 std::shared_ptr<Station> CreateStation();

--- a/src/tile_def.hpp
+++ b/src/tile_def.hpp
@@ -33,11 +33,12 @@ private:
     const std::unordered_set<std::shared_ptr<Component>> refComponents;
     const std::shared_ptr<SpriteDef> refSprite;
     const Vector2Int iconOffset;
+    const std::unordered_map<std::string, int> buildResources;
 
 public:
     TileDef(const std::string &id, Height height, Category category, const std::unordered_set<std::shared_ptr<Component>> &refComponents,
-            const std::shared_ptr<SpriteDef> &refSprite, const Vector2Int &iconOffset)
-        : id(id), height(height), category(category), refComponents(refComponents), refSprite(refSprite), iconOffset(iconOffset) {}
+            const std::shared_ptr<SpriteDef> &refSprite, const Vector2Int &iconOffset, const std::unordered_map<std::string, int> &buildResources)
+        : id(id), height(height), category(category), refComponents(refComponents), refSprite(refSprite), iconOffset(iconOffset), buildResources(buildResources) {}
 
     constexpr const std::string &GetId() const { return id; }
     constexpr std::string GetName() const { return MacroCaseToName(id); }
@@ -46,6 +47,7 @@ public:
     constexpr const std::unordered_set<std::shared_ptr<Component>> &GetReferenceComponents() const { return refComponents; }
     constexpr const std::shared_ptr<SpriteDef> &GetReferenceSprite() const { return refSprite; }
     constexpr const Vector2Int &GetIconOffset() const { return iconOffset; }
+    constexpr const std::unordered_map<std::string, int> &GetBuildResources() const { return buildResources; }
 };
 
 template <>

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -557,6 +557,28 @@ void DrawFpsCounter()
     DrawTextEx(font, text, Vector2(GetScreenSize().x - MeasureTextEx(font, text, DEFAULT_FONT_SIZE, 1).x - DEFAULT_PADDING, DEFAULT_PADDING), DEFAULT_FONT_SIZE, 1, UI_TEXT_COLOR);
 }
 
+void DrawResourceUI()
+{
+    auto station = GameManager::GetStation();
+    if (!station)
+        return;
+
+    Font font = AssetManager::GetFont("DEFAULT");
+    float yOffset = DEFAULT_PADDING;
+
+    // Get all resource definitions to show all resources, even if count is 0
+    const auto &resourceDefs = DefinitionManager::GetResourceDefinitions();
+
+    for (const auto &[resourceId, resourceDef] : resourceDefs)
+    {
+        int count = station->GetResourceCount(resourceId);
+        std::string resourceText = std::format("{}: {}", MacroCaseToName(resourceId), count);
+        const char *text = resourceText.c_str();
+        DrawTextEx(font, text, Vector2(DEFAULT_PADDING, yOffset), DEFAULT_FONT_SIZE, 1, UI_TEXT_COLOR);
+        yOffset += DEFAULT_FONT_SIZE + DEFAULT_PADDING / 2;
+    }
+}
+
 /**
  * Draws a tooltip with a background rectangle at the specified position.
  *

--- a/src/ui.hpp
+++ b/src/ui.hpp
@@ -11,6 +11,7 @@ void DrawCrew();
 void DrawCrewActionProgress();
 void DrawDragSelectBox();
 void DrawFpsCounter();
+void DrawResourceUI();
 void DrawTooltip(const std::string &tooltip, const Vector2 &pos, float padding = DEFAULT_PADDING, int fontSize = DEFAULT_FONT_SIZE);
 void DrawMainTooltip();
 void DrawBuildUi();


### PR DESCRIPTION
Add a yaml file for resources (simple things for now, like metal, electronics). Resource Definitions don't need much parameters for now, just id and price maybe for now. 

Store resources virtually in the Station struct. 

Update tile definitions to list build resources. Then when building, use the resources from the Station. If missing resources allow planning but dont allow building it.

